### PR TITLE
First pass at issue score analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ ghviz
 dashboard/node_modules/
 dashboard/bundle.js
 dashboard/bundle.min.js
+highscores/highscores

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -78,14 +78,16 @@ func TestPagination(t *testing.T) {
 }
 
 const issuesJson string = `[
-{"created_at":"2016-03-07T03:26:14.739Z","closed_at":null,
- "events_url":"https://api.example.com/issues/1/events"},
+{"created_at":"2016-03-07T03:26:14.739Z","closed_at":null,"number":1,
+"events_url":"https://api.example.com/issues/1/events","user":{"login":"tester"}},
 {"created_at":"2016-03-07T03:23:53.002Z","closed_at":"2016-03-07T03:25:41.469Z",
- "events_url":"https://api.example.com/issues/2/events"},
+ "events_url":"https://api.example.com/issues/2/events","number":2,
+ "user":{"login":"tester"}},
 {"created_at":"2016-03-07T03:46:36.717Z","closed_at":"2016-03-07T03:46:55.993Z",
- "pull_request":{},"events_url":"https://api.example.com/issues/3/events"},
-{"created_at":"2016-03-07T03:46:46.458Z","pull_request":{},
- "events_url":"https://api.example.com/issues/4/events"}]`
+ "pull_request":{},"events_url":"https://api.example.com/issues/3/events",
+ "number":3,"user":{"login":"tester"}},
+ {"created_at":"2016-03-07T03:46:46.458Z","pull_request":{},"number":4,
+ "events_url":"https://api.example.com/issues/4/events","user":{"login":"tester"}}]`
 
 func TestListIssues(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +113,8 @@ func TestListIssues(t *testing.T) {
 }
 
 const issuesBadCreatedAtJson = `[
-{"created_at":"fish","events_url":"https://api.example.com/issues/1/events"}]`
+{"created_at":"fish","events_url":"https://api.example.com/issues/1/events",
+ "number":1,"user":{"login":"tester"}}]`
 
 func TestListIssuesBadCreatedAt(t *testing.T) {
 	t.SkipNow()
@@ -129,8 +132,8 @@ func TestListIssuesBadCreatedAt(t *testing.T) {
 }
 
 const issuesBadClosedAtJson = `[
-{"created_at":"2016-03-07T03:26:14.739Z","closed_at":"fish",
- "events_url":"https://api.example.com/issues/1/events"}]`
+{"created_at":"2016-03-07T03:26:14.739Z","closed_at":"fish","number":1,
+ "events_url":"https://api.example.com/issues/1/events","user":{"login":"tester"}}]`
 
 func TestListIssuesBadClosedAt(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/highscores/main.go
+++ b/highscores/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ksheedlo/ghviz/github"
+	"github.com/ksheedlo/ghviz/simulate"
+	"gopkg.in/redis.v3"
+)
+
+func withDefaultStr(config, default_ string) string {
+	if config == "" {
+		return default_
+	}
+	return config
+}
+
+func main() {
+	var redisClient *redis.Client
+	if redisHost := os.Getenv("GHVIZ_REDIS_HOST"); redisHost != "" {
+		redisPort := withDefaultStr(os.Getenv("GHVIZ_REDIS_PORT"), "6379")
+		redisClient = redis.NewClient(&redis.Options{
+			Addr:     fmt.Sprintf("%s:%s", redisHost, redisPort),
+			Password: os.Getenv("GHVIZ_REDIS_PASSWORD"),
+			DB:       0,
+		})
+	}
+
+	gh := github.NewClient(&github.Options{
+		RedisClient: redisClient,
+		Token:       os.Getenv("GITHUB_TOKEN"),
+	})
+	logger := log.New(os.Stderr, "", log.Ldate|log.Ltime|log.Lshortfile|log.LUTC)
+	issues, err := gh.ListIssues(logger, os.Getenv("GHVIZ_OWNER"), os.Getenv("GHVIZ_REPO"))
+	if err != nil {
+		logger.Fatal(err)
+	}
+	c := make(chan map[string]int)
+	numPrs := 0
+	for i, issue := range issues {
+		if issue.IsPr {
+			numPrs++
+			go func(ii int) {
+				logger.Printf("Fetching events for PR #%d", issues[ii].Number)
+				issueEvents, err := gh.ListIssueEvents(logger, &issues[ii])
+				if err != nil {
+					logger.Printf(
+						"ERROR: %s; issue %d will not contribute to scoring.",
+						err.Error(),
+						issues[ii].Number,
+					)
+					c <- make(map[string]int)
+					return
+				}
+				scoringEvents := simulate.ScoreIssue(issueEvents, "ready for review")
+				issueScores := simulate.ScoreEvents(scoringEvents)
+				c <- issueScores
+			}(i)
+		}
+	}
+	totalScores := make(map[string]int)
+	for i := 0; i < numPrs; i++ {
+		issueScores := <-c
+		for userId, score := range issueScores {
+			totalScores[userId] = totalScores[userId] + score
+		}
+	}
+	for userId, score := range totalScores {
+		fmt.Printf("%d %s\n", score, userId)
+	}
+}

--- a/simulate/scores.go
+++ b/simulate/scores.go
@@ -1,0 +1,88 @@
+package simulate
+
+import (
+	"time"
+
+	"github.com/ksheedlo/ghviz/github"
+)
+
+type ScoringEventType int
+
+const (
+	IssueOpened ScoringEventType = iota
+	IssueReviewed
+)
+
+type PrState int
+
+const (
+	PrStateSubmitted PrState = iota
+	PrStateReady
+	PrStateReviewed
+)
+
+type ScoringEvent struct {
+	ActorId   string
+	EventType ScoringEventType
+	Timestamp time.Time
+}
+
+func ScoreIssue(issueEvents []github.DetailedIssueEvent, readyLabel string) []ScoringEvent {
+	var scoringEvents []ScoringEvent
+	prState := PrStateSubmitted
+	for _, event := range issueEvents {
+		switch event.EventType {
+		case github.IssueCreated:
+			// 1, Creating the issue counts as a submission.
+			scoringEvents = append(scoringEvents, ScoringEvent{
+				ActorId:   event.ActorId,
+				EventType: IssueOpened,
+				Timestamp: event.CreatedAt,
+			})
+		case github.IssueLabeled:
+			// 2. The submitter should apply the ready label when the PR is ready
+			//    for review.
+			labelName := (event.Detail.(map[string]interface{}))["name"].(string)
+			if labelName == readyLabel {
+				prState = PrStateReady
+			}
+		case github.IssueUnlabeled:
+			// 3. When a reviewer removes the ready label from a PR in the ready
+			//    state, that constitutes a review.
+			labelName := (event.Detail.(map[string]interface{}))["name"].(string)
+			if labelName == readyLabel && prState == PrStateReady {
+				prState = PrStateReviewed
+				scoringEvents = append(scoringEvents, ScoringEvent{
+					ActorId:   event.ActorId,
+					EventType: IssueReviewed,
+					Timestamp: event.CreatedAt,
+				})
+			}
+		case github.IssueClosed, github.IssueMerged:
+			// 4. If a reviewer merges a PR from the ready state, that also
+			//    constitutes a review. This is a shorthand version of case 3.
+			if prState == PrStateReady {
+				prState = PrStateReviewed
+				scoringEvents = append(scoringEvents, ScoringEvent{
+					ActorId:   event.ActorId,
+					EventType: IssueReviewed,
+					Timestamp: event.CreatedAt,
+				})
+			}
+		}
+	}
+	return scoringEvents
+}
+
+func ScoreEvents(scoringEvents []ScoringEvent) map[string]int {
+	scores := make(map[string]int)
+	for _, event := range scoringEvents {
+		switch event.EventType {
+		case IssueOpened:
+			scores[event.ActorId] = scores[event.ActorId] + 200
+		case IssueReviewed:
+			scores[event.ActorId] = scores[event.ActorId] + 1000
+		}
+	}
+	return scores
+}


### PR DESCRIPTION
/cc @glyph

This implements a really simple model of Github scoring as discussed and based on https://twistedmatrix.com/highscores/. The included `highscores` program prints out the following scoreboard when run against rackerlabs/mimic, which looks reasonable to me:

```
125600 glyph
79600 lekhajee
37400 ksheedlo
30200 cyli
12600 tawalton
5400 ziadsawalha
5400 derwolfe
4600 tokunbo
3800 kivattik
2600 gabecase
2400 sam-falvo
1800 radix
1400 manishtomar
1000 tpboudreau-rackspace
800 lvh
400 wbrothers
400 reaperhulk
400 malini-kamalambal
400 dragorosson
200 stevepeak
200 nyasukun
200 migibert
200 maxlinc
200 leemunroe
200 kaustavha
200 jirwin
200 ddunlop
200 ayersek64
200 amitgandhinz
```

TODO: add tests, consider caching the scoring events or issue events so we're not constantly hitting the API.
